### PR TITLE
Fix 403 Forbidden Error by Adding User-Agent Header

### DIFF
--- a/pocketmagstopdf.py
+++ b/pocketmagstopdf.py
@@ -84,6 +84,9 @@ Options:
                                 Only used with '--quality=original'.
                                 [default: False]
 
+    --user-agent=USER-AGENT     Sometimes requests will fail with 403 Forbidden responses if no User-Agent header is specified
+                                [default: Mozilla/5.0.0]
+
     --quiet                     Suppress printing of all output except warning and error messages.
                                 [default: False]
 
@@ -126,7 +129,7 @@ from io import BytesIO
 from time import sleep
 from urllib.error import HTTPError
 from urllib.parse import urlparse, urlunparse
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 import logging
 
 import PIL
@@ -244,6 +247,7 @@ def main():
     user_uuid_hide = bool(opts['--uuid-hide'])
     user_uuid_destroy = bool(opts['--uuid-destroy'])
     timestamp_change = bool(opts['--timestamp-change'])
+    user_agent = str(opts['--user-agent'])
     quiet = bool(opts['--quiet'])
     debug = bool(opts['--debug'])
 
@@ -318,6 +322,9 @@ def main():
                 raise RuntimeError('User UUID supplied with \'--uuid=\' is not a valid UUID')
         if user_uuid_randomise == True:
             user_uuid = str(uuid.uuid4())
+    headers = {}
+    if user_agent:
+        headers["User-Agent"] = user_agent
 
     LOGGER.info('URL is {}'.format(url.geturl()))
     LOGGER.info('File is {}'.format(pdf_fn))
@@ -333,6 +340,7 @@ def main():
     LOGGER.info('Hide User UUID is {}'.format(str(user_uuid_hide).lower()))
     LOGGER.info('Destroy User UUID is {}'.format(str(user_uuid_destroy).lower()))
     LOGGER.info('Change timestamp is {}'.format(str(timestamp_change).lower()))
+    LOGGER.info('User-Agent is {}'.format(str(user_agent)))
     LOGGER.info('Quiet output is {}'.format(str(quiet).lower()))
     LOGGER.info('Debug output is {}'.format(str(debug).lower()))
 
@@ -358,7 +366,8 @@ def main():
                 page_url = urlunparse(page_url)
 
                 try:
-                    with urlopen(page_url) as f:
+                    req = Request(page_url , headers=headers)
+                    with urlopen(req) as f:
                         LOGGER.info('Downloading page {} from {}...'.format(page_num + 1, page_url))
 
                         # if: the extralow, low & mid quality "jpg" format URLs


### PR DESCRIPTION
pocketmags now blocks requests that do not include User-Agent headers.

Added user-agent option to resolve this issue.
```
--user-agent=USER-AGENT     Sometimes requests will fail with 403 Forbidden responses if no User-Agent header is specified
                            [default: Mozilla/5.0.0]
```